### PR TITLE
Release 0.0.1: fix CMakeLists.txt

### DIFF
--- a/asa_ros/CMakeLists.txt
+++ b/asa_ros/CMakeLists.txt
@@ -33,11 +33,11 @@ add_library(${PROJECT_NAME}
   src/internal/asa_helper.cpp
 )
 target_link_libraries(${PROJECT_NAME}
-    AzureSpatialAnchors::AzureSpatialAnchors
-    Eigen3::Eigen
-    ${GLOG_LIBRARIES}
-    ${Gflags_LIBRARIES}
-    ${catkin_LIBRARIES}
+    PRIVATE AzureSpatialAnchors::AzureSpatialAnchors
+    PUBLIC Eigen3::Eigen
+    PUBLIC ${GLOG_LIBRARIES}
+    PUBLIC ${Gflags_LIBRARIES}
+    PUBLIC ${catkin_LIBRARIES}
 )
 
 ############

--- a/asa_ros/package.xml
+++ b/asa_ros/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>asa_ros</name>
-  <version>0.0.0</version>
+  <version>0.0.1</version>
   <description>ROS wrapper for the Azure Spatial Anchors Linux SDK.</description>
 
   <maintainer email="helen.oleynikova@microsoft.com">Helen Oleynikova</maintainer>

--- a/asa_ros_msgs/package.xml
+++ b/asa_ros_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>asa_ros_msgs</name>
-  <version>0.0.0</version>
+  <version>0.0.1</version>
   <description>Message definitions for the ASA ROS interface.</description>
 
   <maintainer email="helen.oleynikova@microsoft.com">Helen Oleynikova</maintainer>


### PR DESCRIPTION
- Links the Azure Spatial Anchors ROS library correctly in the CMake.
- Update version to 0.0.1