### PR TITLE
Release 0.0.3, plumb through support for RGB images, add TF timeouts

### DIFF
--- a/asa_ros/include/asa_ros/asa_ros_node.h
+++ b/asa_ros/include/asa_ros/asa_ros_node.h
@@ -97,6 +97,10 @@ class AsaRosNode {
   std::string camera_frame_id_;
   std::string anchor_frame_id_;
 
+  // Timeout to wait for TF messages, in seconds. 0.0 = instantaneous. 1.0 =
+  // will wait a full second on any failed attempt.
+  double tf_lookup_timeout_;
+
   // Cache of which anchors are currently being queried. This will be only used
   // when reset() (but not resetCompletely() is called, to restart any
   // previous watchers.

--- a/asa_ros/launch/asa_ros.launch
+++ b/asa_ros/launch/asa_ros.launch
@@ -17,8 +17,12 @@
     <remap from="image" to="/camera/fisheye1_rect/image" />
     <remap from="camera_info" to="/camera/fisheye1_rect/camera_info" />
 
+    <!-- The frame ID of your world/odometry frame. Should be static relative to, well, the world. -->
     <param name="world_frame_id" value="camera_odom_frame" />
+    <!-- Optical frame of the camera, z facing "forward" (out of the camera frame). -->
     <param name="camera_frame_id" value="camera_fisheye1_optical_frame" />
+    <!-- Timeout to wait for TF lookups to finish. If you get a lot of TF errors but still smome valid lookups, try increasing this. -->
+    <param name="tf_lookup_timeout" value="0.1" />
 
     <param name="account_id" value="$(arg account_id)"/>
     <param name="account_key" value="$(arg account_key)"/>

--- a/asa_ros/package.xml
+++ b/asa_ros/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>asa_ros</name>
-  <version>0.0.1</version>
+  <version>0.0.3</version>
   <description>ROS wrapper for the Azure Spatial Anchors Linux SDK.</description>
 
   <maintainer email="helen.oleynikova@microsoft.com">Helen Oleynikova</maintainer>

--- a/asa_ros/src/asa_interface.cpp
+++ b/asa_ros/src/asa_interface.cpp
@@ -188,7 +188,7 @@ void AzureSpatialAnchorsInterface::addFrame(
   double cy = camera_msg.K[5];
 
   // Convert the image.
-  cv::Mat image = cv_bridge::toCvCopy(image_msg)->image;
+  cv::Mat image = cv_bridge::toCvCopy(image_msg, "mono8")->image;
 
   // Convert the pose.
   Eigen::Affine3d T_W_C = tf2::transformToEigen(T_W_C_msg);

--- a/asa_ros/src/asa_ros_provider.cpp
+++ b/asa_ros/src/asa_ros_provider.cpp
@@ -31,7 +31,7 @@ void AsaRosProvider::GetPixelData(const void* frame_context,
   const auto iter = image_queue_.find(image_key);
   if (iter != image_queue_.end()) {
     const cv::Mat& image = iter->second;
-    size_t image_size = image.total() * image.elemSize();
+    size_t image_size = image.total() * image.elemSize() * image.channels();
     if (image_size != buffer_size) {
       LOG(ERROR) << "Image size and buffer size don't match! Image size: "
                  << image_size << " Buffer size: " << buffer_size;

--- a/asa_ros/src/asa_ros_provider.cpp
+++ b/asa_ros/src/asa_ros_provider.cpp
@@ -47,7 +47,7 @@ size_t AsaRosProvider::addImageToQueue(const cv::Mat& image) {
   std::unique_lock<std::mutex> provider_lock(provider_mutex_);
   if (image.channels() > 1) {
     cv::Mat gray_image;
-    cv::cvtColor(image, gray_image, cv::COLOR_RGB2GRAY);
+    cv::cvtColor(image, gray_image, cv::COLOR_BGR2GRAY);
     image_queue_[next_queue_id_] = gray_image;
   } else {
     image_queue_[next_queue_id_] = image;

--- a/asa_ros/src/asa_ros_provider.cpp
+++ b/asa_ros/src/asa_ros_provider.cpp
@@ -31,7 +31,7 @@ void AsaRosProvider::GetPixelData(const void* frame_context,
   const auto iter = image_queue_.find(image_key);
   if (iter != image_queue_.end()) {
     const cv::Mat& image = iter->second;
-    size_t image_size = image.total() * image.elemSize() * image.channels();
+    size_t image_size = image.total() * image.elemSize();
     if (image_size != buffer_size) {
       LOG(ERROR) << "Image size and buffer size don't match! Image size: "
                  << image_size << " Buffer size: " << buffer_size;
@@ -45,7 +45,13 @@ void AsaRosProvider::GetPixelData(const void* frame_context,
 
 size_t AsaRosProvider::addImageToQueue(const cv::Mat& image) {
   std::unique_lock<std::mutex> provider_lock(provider_mutex_);
-  image_queue_[next_queue_id_] = image;
+  if (image.channels() > 1) {
+    cv::Mat gray_image;
+    cv::cvtColor(image, gray_image, cv::COLOR_RGB2GRAY);
+    image_queue_[next_queue_id_] = gray_image;
+  } else {
+    image_queue_[next_queue_id_] = image;
+  }
 
   VLOG(3) << "Added image " << next_queue_id_ << " to queue.\n";
 

--- a/asa_ros_msgs/package.xml
+++ b/asa_ros_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>asa_ros_msgs</name>
-  <version>0.0.1</version>
+  <version>0.0.3</version>
   <description>Message definitions for the ASA ROS interface.</description>
 
   <maintainer email="helen.oleynikova@microsoft.com">Helen Oleynikova</maintainer>


### PR DESCRIPTION
* Now converts RGB/BGR images to mono8 when converting from ROS
* New parameter: `tf_lookup_timeout`, how long to wait for TF lookups to be successful. Current default is 0.1, if getting lots of TF lookup errors, consider trying to increase this.