### PR TITLE
Add an optional feature to enable an approximate time synchronization

### DIFF
--- a/asa_ros/include/asa_ros/asa_ros_node.h
+++ b/asa_ros/include/asa_ros/asa_ros_node.h
@@ -27,7 +27,7 @@
 namespace asa_ros {
 
 
-  typedef message_filters::sync_policies::ApproximateTime<sensor_msgs::Image,
+typedef message_filters::sync_policies::ApproximateTime<sensor_msgs::Image,
                                             sensor_msgs::CameraInfo> CameraSyncPolicy;
 
 
@@ -78,11 +78,9 @@ class AsaRosNode {
   std::unique_ptr<message_filters::Synchronizer<CameraSyncPolicy>>
       image_info_approx_sync_;
       
-   std::unique_ptr<message_filters::TimeSynchronizer<sensor_msgs::Image,
+  std::unique_ptr<message_filters::TimeSynchronizer<sensor_msgs::Image,
                                                     sensor_msgs::CameraInfo>>
-      image_info_sync_;
-
-      
+      image_info_sync_; 
 
   // Pubs & subs
   ros::Publisher found_anchor_pub_;
@@ -112,11 +110,12 @@ class AsaRosNode {
   // will wait a full second on any failed attempt.
   double tf_lookup_timeout_;
 
-  // A flag indicating that the node will use an approximate time synchronization policy 
-  // to synchronize the images with the camera_info messages instead of the exact syncher
+  // A flag indicating that the node will use an approximate time synchronization  
+  // policy to synchronize the images with the camera_info messages instead of the 
+  // exact synchronizer
   bool use_approx_sync_policy;
 
-  // The que size of the subscribers used for approximate time policy synchronization
+  // The que size of the subscribers used for the image and camera_info topic
   int que_size;
 
   // Cache of which anchors are currently being queried. This will be only used

--- a/asa_ros/include/asa_ros/asa_ros_node.h
+++ b/asa_ros/include/asa_ros/asa_ros_node.h
@@ -115,8 +115,8 @@ class AsaRosNode {
   // exact synchronizer
   bool use_approx_sync_policy;
 
-  // The que size of the subscribers used for the image and camera_info topic
-  int que_size;
+  // The queue size of the subscribers used for the image and camera_info topic
+  int queue_size;
 
   // Cache of which anchors are currently being queried. This will be only used
   // when reset() (but not resetCompletely() is called, to restart any

--- a/asa_ros/launch/asa_ros.launch
+++ b/asa_ros/launch/asa_ros.launch
@@ -13,6 +13,12 @@
   <!-- Whether to print verbose status updated on every ingested frame. Very spammy. -->
   <arg name="print_status" default="false" />
 
+  <!-- Use approximate time synchronization between the image and camera_info topic-->
+  <arg name="use_approx_sync_policy" default="false"/>
+
+  <!-- Que size of the image and camera_info subscriber -->
+  <arg name="subscriber_que_size" default="1"/>
+
   <node name="asa_ros" type="asa_ros_node" pkg="asa_ros" output="screen" clear_params="true">
     <remap from="image" to="/camera/fisheye1_rect/image" />
     <remap from="camera_info" to="/camera/fisheye1_rect/camera_info" />
@@ -31,6 +37,8 @@
     <param name="anchor_frame_id" value="$(arg anchor_frame_id)" />
 
     <param name="print_status" value="$(arg print_status)" />
+    <param name="use_approx_sync_policy" value="$(arg use_approx_sync_policy)"/>
+    <param name="subscriber_que_size" value="$(arg subscriber_que_size)"/>
 
     <param name="anchor_id" value="$(arg anchor_id)" />
   </node>

--- a/asa_ros/launch/asa_ros.launch
+++ b/asa_ros/launch/asa_ros.launch
@@ -17,7 +17,7 @@
   <arg name="use_approx_sync_policy" default="false"/>
 
   <!-- Que size of the image and camera_info subscriber -->
-  <arg name="subscriber_que_size" default="1"/>
+  <arg name="subscriber_queue_size" default="1"/>
 
   <node name="asa_ros" type="asa_ros_node" pkg="asa_ros" output="screen" clear_params="true">
     <remap from="image" to="/camera/fisheye1_rect/image" />
@@ -38,7 +38,7 @@
 
     <param name="print_status" value="$(arg print_status)" />
     <param name="use_approx_sync_policy" value="$(arg use_approx_sync_policy)"/>
-    <param name="subscriber_que_size" value="$(arg subscriber_que_size)"/>
+    <param name="subscriber_queue_size" value="$(arg subscriber_queue_size)"/>
 
     <param name="anchor_id" value="$(arg anchor_id)" />
   </node>

--- a/asa_ros/src/asa_ros_node.cpp
+++ b/asa_ros/src/asa_ros_node.cpp
@@ -27,19 +27,19 @@ AsaRosNode::~AsaRosNode() {}
 
 void AsaRosNode::initFromRosParams() {
 
-  nh_private_.param("subscriber_que_size", que_size, 1);
+  nh_private_.param("subscriber_queue_size", queue_size, 1);
   nh_private_.param("use_approx_sync_policy", use_approx_sync_policy, false);
 
-  if(que_size > 1 || use_approx_sync_policy) {
-    ROS_INFO_STREAM("Starting image and info subscribers with approximate time sync, where que-size is " << que_size);
+  if(queue_size > 1 || use_approx_sync_policy) {
+    ROS_INFO_STREAM("Starting image and info subscribers with approximate time sync, where que-size is " << queue_size);
   }
 
   // Subscribe to the camera images.
-  image_sub_.subscribe(nh_, "image", que_size);
-  info_sub_.subscribe(nh_, "camera_info", que_size);
+  image_sub_.subscribe(nh_, "image", queue_size);
+  info_sub_.subscribe(nh_, "camera_info", queue_size);
   
   if(use_approx_sync_policy) {
-    image_info_approx_sync_.reset(new message_filters::Synchronizer<CameraSyncPolicy>(CameraSyncPolicy(que_size), image_sub_, info_sub_));
+    image_info_approx_sync_.reset(new message_filters::Synchronizer<CameraSyncPolicy>(CameraSyncPolicy(queue_size), image_sub_, info_sub_));
     image_info_approx_sync_->registerCallback(boost::bind(&AsaRosNode::imageAndInfoCallback, this, _1, _2));
   } else {
     image_info_sync_.reset(

--- a/asa_ros/src/asa_ros_node.cpp
+++ b/asa_ros/src/asa_ros_node.cpp
@@ -6,7 +6,6 @@
 
 #include "asa_ros/asa_ros_node.h"
 
-
 namespace asa_ros {
 
                                             
@@ -29,30 +28,26 @@ AsaRosNode::~AsaRosNode() {}
 void AsaRosNode::initFromRosParams() {
 
   nh_private_.param("subscriber_que_size", que_size, 1);
+  nh_private_.param("use_approx_sync_policy", use_approx_sync_policy, false);
 
-  if(que_size > 1)
-  {
+  if(que_size > 1 || use_approx_sync_policy) {
     ROS_INFO_STREAM("Starting image and info subscribers with approximate time sync, where que-size is " << que_size);
   }
 
   // Subscribe to the camera images.
   image_sub_.subscribe(nh_, "image", que_size);
   info_sub_.subscribe(nh_, "camera_info", que_size);
-
-  nh_private_.param("use_approx_sync_policy", use_approx_sync_policy, false);
   
-  if(use_approx_sync_policy){
+  if(use_approx_sync_policy) {
     image_info_approx_sync_.reset(new message_filters::Synchronizer<CameraSyncPolicy>(CameraSyncPolicy(que_size), image_sub_, info_sub_));
     image_info_approx_sync_->registerCallback(boost::bind(&AsaRosNode::imageAndInfoCallback, this, _1, _2));
-  }
-  else{
+  } else {
     image_info_sync_.reset(
         new message_filters::TimeSynchronizer<sensor_msgs::Image,
                                               sensor_msgs::CameraInfo>(image_sub_, info_sub_, 10));
     image_info_sync_->registerCallback(
         boost::bind(&AsaRosNode::imageAndInfoCallback, this, _1, _2));
   }
-
 
   // Subscribe to transform topics, if any.
   transform_sub_ =


### PR DESCRIPTION
This PR adds an optional feature to use a time synchronization between the `image` and `camera_info` topics using an approximate synchronization policy from `message_filters/sync_policies/approximate_time`, which solved the issue #10 

Two optional ros-launch parameters were added. The default configuration does *not* use the new feature and runs the node as it did before.


| Param name | default value | description |
| - | :-: | - |
|  `subscriber_que_size` | 1 | An integer representing the que length of the image and camera_info subscriber |
| `use_approx_sync_policy` | false | A flag that indicates whether or not to activate the approximate time synchronization policy |