### PR TITLE
Validate the focal lengths reported by camera_info

### DIFF
--- a/asa_ros/src/asa_ros_node.cpp
+++ b/asa_ros/src/asa_ros_node.cpp
@@ -109,6 +109,11 @@ void AsaRosNode::initFromRosParams() {
   }
 }
 
+// Returns true if the camera intrinsics seem to be valid. Does not validate correctness
+bool ValidateCameraIntrinsics(const boost::array<double, 9> K, int image_height, int image_width){
+  return K.at(0) > 0 && K.at(4) > 0 && K.at(2) >= 0 && K.at(5) >= 0 && image_height > 0 && image_width > 0;
+}
+
 void AsaRosNode::imageAndInfoCallback(
     const sensor_msgs::Image::ConstPtr& image,
     const sensor_msgs::CameraInfo::ConstPtr& camera_info) {
@@ -118,9 +123,8 @@ void AsaRosNode::imageAndInfoCallback(
     ROS_INFO_STREAM("Set camera frame ID to " << camera_frame_id_);
   }
 
-  if(camera_info->K[0] == 0 && camera_info->K[4] == 0)
-  {
-    ROS_WARN_ONCE("The camera_info topic reported focal lengths of 0 for x & z. The anchor creation will fail.");
+  if(!ValidateCameraIntrinsics(camera_info->K, image->height, image->width)){
+    ROS_WARN_ONCE("The camera_info topic reported invalid values. The anchor creation will fail. Check the camera configuration.");
   }
 
   // Look up its pose.

--- a/asa_ros/src/asa_ros_node.cpp
+++ b/asa_ros/src/asa_ros_node.cpp
@@ -117,6 +117,12 @@ void AsaRosNode::imageAndInfoCallback(
     camera_frame_id_ = image->header.frame_id;
     ROS_INFO_STREAM("Set camera frame ID to " << camera_frame_id_);
   }
+
+  if(camera_info->K[0] == 0 && camera_info->K[4] == 0)
+  {
+    ROS_WARN_ONCE("The camera_info topic reported focal lengths of 0 for x & z. The anchor creation will fail.");
+  }
+
   // Look up its pose.
   if (tf_buffer_.canTransform(world_frame_id_, camera_frame_id_,
                               image->header.stamp,


### PR DESCRIPTION
This PR warns the user if the camera_info topic reports focal lenghts of zero in the camera_info topic, which results in an Error 400 down the road when trying to create anchors, since the ASA backend can (of course) not handle unkown camera intrinsics.

If you feel like this is not necessary since this is a responsibility of the user, please go ahead and delete this PR.