### PR TITLE
Add optional logging capabilities for debugging

### DIFF
--- a/asa_ros/include/asa_ros/asa_interface.h
+++ b/asa_ros/include/asa_ros/asa_interface.h
@@ -53,9 +53,6 @@ class AzureSpatialAnchorsInterface {
 
   // MUST be called before anything else.
   void start();
-  
-  // Attatches a few logging handlers
-  void ActivateDebugLogging();
 
   // Resets any visual data with the current session.
   // Image data will be wiped, but this would allow you to re-locate anchors
@@ -118,6 +115,9 @@ class AzureSpatialAnchorsInterface {
   static std::string trimWhitespace(const std::string& s);
   static std::vector<std::string> splitByDelimeter(const std::string& s,
                                                    char delimiter);
+  
+  // Attatches a few logging handlers
+  void ActivateInterfaceLevelLogging();
 
  private:
   // Callback for session updates. Currently optionally prints to LOG(INFO).
@@ -126,13 +126,13 @@ class AzureSpatialAnchorsInterface {
       const std::shared_ptr<
           Microsoft::Azure::SpatialAnchors::SessionUpdatedEventArgs>& args);
   
-  // Callback for session debug logs.
+  // Callback for session debug logs invoked by the Linux SDK
   void sessionDebugHandler(
       void*,
       const std::shared_ptr<
           Microsoft::Azure::SpatialAnchors::OnLogDebugEventArgs>& args);
 
-  // Callback for session error logs.
+  // Callback for session error logs invoked by the Linux SDK
   void sessionErrorHandler(
       void*,
       const std::shared_ptr<

--- a/asa_ros/include/asa_ros/asa_interface.h
+++ b/asa_ros/include/asa_ros/asa_interface.h
@@ -19,6 +19,8 @@ class CloudSpatialAnchorSession;
 class CloudSpatialAnchorWatcher;
 class CloudSpatialAnchor;
 class SessionUpdatedEventArgs;
+class OnLogDebugEventArgs;
+class SessionErrorEventArgs;
 struct event_token;
 }  // namespace SpatialAnchors
 }  // namespace Azure
@@ -51,6 +53,9 @@ class AzureSpatialAnchorsInterface {
 
   // MUST be called before anything else.
   void start();
+  
+  // Attatches a few logging handlers
+  void ActivateDebugLogging();
 
   // Resets any visual data with the current session.
   // Image data will be wiped, but this would allow you to re-locate anchors
@@ -120,6 +125,18 @@ class AzureSpatialAnchorsInterface {
       void*,
       const std::shared_ptr<
           Microsoft::Azure::SpatialAnchors::SessionUpdatedEventArgs>& args);
+  
+  // Callback for session debug logs.
+  void sessionDebugHandler(
+      void*,
+      const std::shared_ptr<
+          Microsoft::Azure::SpatialAnchors::OnLogDebugEventArgs>& args);
+
+  // Callback for session error logs.
+  void sessionErrorHandler(
+      void*,
+      const std::shared_ptr<
+          Microsoft::Azure::SpatialAnchors::SessionErrorEventArgs>& args);
 
   // Cache the configuration settings for stuff that needs to be used at
   // run-time.
@@ -157,6 +174,10 @@ class AzureSpatialAnchorsInterface {
       session_update_token_;
   std::unique_ptr<Microsoft::Azure::SpatialAnchors::event_token>
       anchor_located_token_;
+  std::unique_ptr<Microsoft::Azure::SpatialAnchors::event_token>
+      session_debuglog_token_;
+  std::unique_ptr<Microsoft::Azure::SpatialAnchors::event_token>
+      session_error_token_;
 
   // Keep track of how many frames were added.
   size_t frame_count_;

--- a/asa_ros/include/asa_ros/asa_ros_node.h
+++ b/asa_ros/include/asa_ros/asa_ros_node.h
@@ -118,6 +118,9 @@ class AsaRosNode {
   // The queue size of the subscribers used for the image and camera_info topic
   int queue_size;
 
+  // A flag that tells the asa interface to log debug logs
+  bool activate_logging;
+
   // Cache of which anchors are currently being queried. This will be only used
   // when reset() (but not resetCompletely() is called, to restart any
   // previous watchers.

--- a/asa_ros/include/asa_ros/asa_ros_node.h
+++ b/asa_ros/include/asa_ros/asa_ros_node.h
@@ -119,7 +119,7 @@ class AsaRosNode {
   int queue_size;
 
   // A flag that tells the asa interface to log debug logs
-  bool activate_logging;
+  bool activate_interface_level_logging;
 
   // Cache of which anchors are currently being queried. This will be only used
   // when reset() (but not resetCompletely() is called, to restart any

--- a/asa_ros/launch/asa_ros.launch
+++ b/asa_ros/launch/asa_ros.launch
@@ -19,7 +19,8 @@
   <!-- Que size of the image and camera_info subscriber -->
   <arg name="subscriber_queue_size" default="1"/>
 
-  <arg name="activate_interface_logging" default="false"/>
+  <!-- If true the asa interface loggs Debug Messages and Errors to the screen -->
+  <arg name="activate_interface_level_logging" default="false"/>
 
   <node name="asa_ros" type="asa_ros_node" pkg="asa_ros" output="screen" clear_params="true">
     <remap from="image" to="/camera/fisheye1_rect/image" />
@@ -41,7 +42,7 @@
     <param name="print_status" value="$(arg print_status)" />
     <param name="use_approx_sync_policy" value="$(arg use_approx_sync_policy)"/>
     <param name="subscriber_queue_size" value="$(arg subscriber_queue_size)"/>
-    <param name="activate_interface_logging" value="$(arg activate_interface_logging)"/>
+    <param name="activate_interface_level_logging" value="$(arg activate_interface_level_logging)"/>
 
     <param name="anchor_id" value="$(arg anchor_id)" />
   </node>

--- a/asa_ros/launch/asa_ros.launch
+++ b/asa_ros/launch/asa_ros.launch
@@ -19,6 +19,8 @@
   <!-- Que size of the image and camera_info subscriber -->
   <arg name="subscriber_queue_size" default="1"/>
 
+  <arg name="activate_interface_logging" default="false"/>
+
   <node name="asa_ros" type="asa_ros_node" pkg="asa_ros" output="screen" clear_params="true">
     <remap from="image" to="/camera/fisheye1_rect/image" />
     <remap from="camera_info" to="/camera/fisheye1_rect/camera_info" />
@@ -39,6 +41,7 @@
     <param name="print_status" value="$(arg print_status)" />
     <param name="use_approx_sync_policy" value="$(arg use_approx_sync_policy)"/>
     <param name="subscriber_queue_size" value="$(arg subscriber_queue_size)"/>
+    <param name="activate_interface_logging" value="$(arg activate_interface_logging)"/>
 
     <param name="anchor_id" value="$(arg anchor_id)" />
   </node>

--- a/asa_ros/src/asa_interface.cpp
+++ b/asa_ros/src/asa_interface.cpp
@@ -237,7 +237,6 @@ bool AzureSpatialAnchorsInterface::createAnchor(
     LOG(INFO) << "Spatial Anchor Identifier = " << asa_anchor->Identifier();
 
   } catch (std::exception& e) {
-    LOG(ERROR) << "Exception thrown on line 239";
     LOG(ERROR) << "Failed to create anchor: " << e.what();
     return false;
   }
@@ -293,7 +292,6 @@ bool AzureSpatialAnchorsInterface::createAnchorWithCallback(
           create_anchor_mutex_.unlock();
         });
   } catch (std::exception& e) {
-    LOG(ERROR) << "Exception thrown on line 292";
     LOG(ERROR) << "Failed to create anchor: " << e.what();
     frame_mutex_.unlock();
     create_anchor_mutex_.unlock();

--- a/asa_ros/src/asa_interface.cpp
+++ b/asa_ros/src/asa_interface.cpp
@@ -69,47 +69,6 @@ AzureSpatialAnchorsInterface::AzureSpatialAnchorsInterface(
   }
 }
 
-void AzureSpatialAnchorsInterface::ActivateDebugLogging(){
-  
-  session_->LogLevel(Microsoft::Azure::SpatialAnchors::SessionLogLevel::All);
-  session_->Diagnostics()->LogLevel(Microsoft::Azure::SpatialAnchors::SessionLogLevel::All);
-  session_->Diagnostics()->LogDirectory("/home/mrdrone/");
-  LOG(INFO) << "Diagnostics LogDirectory: " << session_->Diagnostics()->LogDirectory();
-  LOG(INFO) << "Diagnostics LogLevel: " << (int32_t)session_->Diagnostics()->LogLevel();
-  LOG(INFO) << "Session LogLevel: " << (int32_t)session_->LogLevel();
-
-
-  session_debuglog_token_.reset(
-      new Microsoft::Azure::SpatialAnchors::event_token);
-  *session_debuglog_token_ = session_->OnLogDebug(
-      std::bind(&AzureSpatialAnchorsInterface::sessionDebugHandler, this,
-                std::placeholders::_1, std::placeholders::_2));
-
-  session_error_token_.reset(
-    new asa::event_token);
-
-  *session_error_token_ = session_->Error(
-      std::bind(&AzureSpatialAnchorsInterface::sessionErrorHandler, this,
-                std::placeholders::_1, std::placeholders::_2));
-}
-
-void AzureSpatialAnchorsInterface::sessionDebugHandler(
-    void*,
-    const std::shared_ptr<
-        Microsoft::Azure::SpatialAnchors::OnLogDebugEventArgs>& args){
-  LOG(INFO) << args->Message();
-}
-
-void AzureSpatialAnchorsInterface::sessionErrorHandler(
-    void*,
-    const std::shared_ptr<
-        Microsoft::Azure::SpatialAnchors::SessionErrorEventArgs>& args){
-  LOG(INFO) << "----- ERROR -----";
-  LOG(INFO) << "Error Code: " << (int32_t)args->ErrorCode();
-  LOG(INFO) << "Error Message: " << args->ErrorMessage();
-}
-
-
 void AzureSpatialAnchorsInterface::start() {
   // Create a session handle and session.
   asa_session_handle context_handle =
@@ -542,5 +501,47 @@ bool AzureSpatialAnchorsInterface::isValidUuid(const std::string& id) {
       "9a-fA-F]{12}");
   return std::regex_match(id, uuid_regex);
 }
+
+
+void AzureSpatialAnchorsInterface::ActivateInterfaceLevelLogging(){
+  
+  session_->LogLevel(Microsoft::Azure::SpatialAnchors::SessionLogLevel::All);
+  session_->Diagnostics()->LogLevel(Microsoft::Azure::SpatialAnchors::SessionLogLevel::All);
+  session_->Diagnostics()->LogDirectory("/home/mrdrone/");
+  LOG(INFO) << "Diagnostics LogDirectory: " << session_->Diagnostics()->LogDirectory();
+  LOG(INFO) << "Diagnostics LogLevel: " << (int32_t)session_->Diagnostics()->LogLevel();
+  LOG(INFO) << "Session LogLevel: " << (int32_t)session_->LogLevel();
+
+
+  session_debuglog_token_.reset(
+      new Microsoft::Azure::SpatialAnchors::event_token);
+  *session_debuglog_token_ = session_->OnLogDebug(
+      std::bind(&AzureSpatialAnchorsInterface::sessionDebugHandler, this,
+                std::placeholders::_1, std::placeholders::_2));
+
+  session_error_token_.reset(
+    new asa::event_token);
+
+  *session_error_token_ = session_->Error(
+      std::bind(&AzureSpatialAnchorsInterface::sessionErrorHandler, this,
+                std::placeholders::_1, std::placeholders::_2));
+}
+
+void AzureSpatialAnchorsInterface::sessionDebugHandler(
+    void*,
+    const std::shared_ptr<
+        Microsoft::Azure::SpatialAnchors::OnLogDebugEventArgs>& args){
+  LOG(INFO) << args->Message();
+}
+
+void AzureSpatialAnchorsInterface::sessionErrorHandler(
+    void*,
+    const std::shared_ptr<
+        Microsoft::Azure::SpatialAnchors::SessionErrorEventArgs>& args){
+  LOG(ERROR) << "----- ERROR -----";
+  LOG(ERROR) << "Error Code: " << (int32_t)args->ErrorCode();
+  LOG(ERROR) << "Error Message: " << args->ErrorMessage();
+}
+
 
 }  // namespace asa_ros

--- a/asa_ros/src/asa_ros_node.cpp
+++ b/asa_ros/src/asa_ros_node.cpp
@@ -29,7 +29,7 @@ void AsaRosNode::initFromRosParams() {
 
   nh_private_.param("subscriber_queue_size", queue_size, 1);
   nh_private_.param("use_approx_sync_policy", use_approx_sync_policy, false);
-  nh_private_.param("activate_interface_logging", activate_logging, false);
+  nh_private_.param("activate_interface_level_logging", activate_interface_level_logging, false);
 
   if(queue_size > 1 || use_approx_sync_policy) {
     ROS_INFO_STREAM("Starting image and info subscribers with approximate time sync, where que-size is " << queue_size);
@@ -97,10 +97,12 @@ void AsaRosNode::initFromRosParams() {
                                      << " account key: "
                                      << asa_config.account_key);
 
-    interface_.reset(new AzureSpatialAnchorsInterface(asa_config));
-  if(activate_logging){
-    interface_->ActivateDebugLogging();
+  interface_.reset(new AzureSpatialAnchorsInterface(asa_config));
+
+  if(activate_interface_level_logging){
+    interface_->ActivateInterfaceLevelLogging();
   }
+  
   interface_->start();
 
   std::string anchor_id;

--- a/asa_ros/src/asa_ros_node.cpp
+++ b/asa_ros/src/asa_ros_node.cpp
@@ -29,6 +29,7 @@ void AsaRosNode::initFromRosParams() {
 
   nh_private_.param("subscriber_queue_size", queue_size, 1);
   nh_private_.param("use_approx_sync_policy", use_approx_sync_policy, false);
+  nh_private_.param("activate_interface_logging", activate_logging, false);
 
   if(queue_size > 1 || use_approx_sync_policy) {
     ROS_INFO_STREAM("Starting image and info subscribers with approximate time sync, where que-size is " << queue_size);
@@ -96,7 +97,10 @@ void AsaRosNode::initFromRosParams() {
                                      << " account key: "
                                      << asa_config.account_key);
 
-  interface_.reset(new AzureSpatialAnchorsInterface(asa_config));
+    interface_.reset(new AzureSpatialAnchorsInterface(asa_config));
+  if(activate_logging){
+    interface_->ActivateDebugLogging();
+  }
   interface_->start();
 
   std::string anchor_id;


### PR DESCRIPTION
This PR adds eventhandlers using the two methods `CloudSpatialAnchorSession.OnLogDebug` and `CloudSpatialAnchorSession.Error`, which print out the received information from the API. This setting might help in debugging situations, where the default status prints are not enough. 

Currently there is a parameter for the rosnode to activate this logging behavior, which is false by default. Since this is a very specific feature, we might want to think about removing the param from the default roslaunch file and only documenting it in the Wiki.