### PR TITLE
Publish feedback from SessionUpdateHandler

### DIFF
--- a/asa_ros/include/asa_ros/asa_interface.h
+++ b/asa_ros/include/asa_ros/asa_interface.h
@@ -107,12 +107,19 @@ class AzureSpatialAnchorsInterface {
   bool queryAnchorsWithCallback(const std::vector<std::string>& anchor_ids,
                                 const FoundAnchorCallbackFunction& callback);
 
+  // Set the callback function to publish ancho creating feedback to ROS
+  typedef std::function<void(const float, const float, const std::string&)>
+      CreateAnchorFeedbackCallbackFunction;
+  void setCreateAnchorFeedbackCallback(
+      const CreateAnchorFeedbackCallbackFunction& callback);
+
   // === Helpers ===
   // Validate that a string is a valid UUID for Anchor UUID, account IDs, etc.
   static bool isValidUuid(const std::string& id);
   static std::string trimWhitespace(const std::string& s);
   static std::vector<std::string> splitByDelimeter(const std::string& s,
                                                    char delimiter);
+
 
  private:
   // Callback for session updates. Currently optionally prints to LOG(INFO).
@@ -160,6 +167,9 @@ class AzureSpatialAnchorsInterface {
 
   // Keep track of how many frames were added.
   size_t frame_count_;
+
+  // Callback function to send create anchor feedback to ROS
+  CreateAnchorFeedbackCallbackFunction feedback_callback_;
 
   // Mutex for locking new frames when creating an anchor.
   std::mutex frame_mutex_;

--- a/asa_ros/include/asa_ros/asa_ros_node.h
+++ b/asa_ros/include/asa_ros/asa_ros_node.h
@@ -16,6 +16,7 @@
 #include <asa_ros_msgs/CreatedAnchor.h>
 #include <asa_ros_msgs/FindAnchor.h>
 #include <asa_ros_msgs/FoundAnchor.h>
+#include <asa_ros_msgs/CreateAnchorFeedback.h>
 #include <sensor_msgs/CameraInfo.h>
 #include <sensor_msgs/Image.h>
 #include <std_srvs/Empty.h>
@@ -49,6 +50,9 @@ class AsaRosNode {
                            const Eigen::Affine3d& anchor_in_world_frame);
   void anchorCreatedCallback(bool success, const std::string& anchor_id,
                              const std::string& reason);
+  void createAnchorFeedbackCallback(const float ready_for_create_progress,
+                                    const float recommended_for_create_progress,
+                                    const std::string& user_feedback);
 
   // Service callbacks.
   bool createAnchorCallback(asa_ros_msgs::CreateAnchorRequest& req,
@@ -85,6 +89,7 @@ class AsaRosNode {
   // Pubs & subs
   ros::Publisher found_anchor_pub_;
   ros::Publisher created_anchor_pub_;
+  ros::Publisher feedback_pub_;
   ros::Subscriber transform_sub_;
 
   // Services.

--- a/asa_ros/src/asa_interface.cpp
+++ b/asa_ros/src/asa_interface.cpp
@@ -454,15 +454,31 @@ void AzureSpatialAnchorsInterface::sessionUpdateHandler(
         Microsoft::Azure::SpatialAnchors::SessionUpdatedEventArgs>& args) {
   std::unique_lock<std::mutex> lock(session_update_mutex_);
 
+  const float ready_for_create_progress =
+      args->Status()->ReadyForCreateProgress();
+  const float recommended_for_create_progress =
+      args->Status()->RecommendedForCreateProgress();
+  const std::string user_feedback =
+      to_string(args->Status()->UserFeedback());
+
+  feedback_callback_(ready_for_create_progress,
+                     recommended_for_create_progress,
+                     user_feedback);
+
   if (config_.print_status) {
     LOG(INFO) << "----------------------------------------------------------\n";
     LOG(INFO) << "      ReadyForCreateProgress : "
-              << args->Status()->ReadyForCreateProgress() << "\n";
+              << ready_for_create_progress << "\n";
     LOG(INFO) << "RecommendedForCreateProgress : "
-              << args->Status()->RecommendedForCreateProgress() << "\n";
+              << recommended_for_create_progress << "\n";
     LOG(INFO) << "                UserFeedback : "
-              << to_string(args->Status()->UserFeedback()) << "\n";
+              << user_feedback << "\n";
   }
+}
+
+void AzureSpatialAnchorsInterface::setCreateAnchorFeedbackCallback(
+    const CreateAnchorFeedbackCallbackFunction& callback) {
+      feedback_callback_ = callback;
 }
 
 std::string AzureSpatialAnchorsInterface::trimWhitespace(const std::string& s) {

--- a/asa_ros_msgs/msg/CreateAnchorFeedback.msg
+++ b/asa_ros_msgs/msg/CreateAnchorFeedback.msg
@@ -1,0 +1,3 @@
+float32 ready_for_create_progress
+float32 recommended_for_create_progress
+string  user_feedback


### PR DESCRIPTION
Piped the SessionUpdateHandler output (e.g. ReadyForCreateAnchorProgress) out to the ROS node.  This is now published on a topic to enable easier monitoring of progress toward sufficient data for anchor creation (or querying).