### PR TITLE
Added target frame to CreateAnchor req

### DIFF
--- a/asa_ros/include/asa_ros/asa_ros_node.h
+++ b/asa_ros/include/asa_ros/asa_ros_node.h
@@ -110,6 +110,10 @@ class AsaRosNode {
   // will wait a full second on any failed attempt.
   double tf_lookup_timeout_;
 
+  // Timestamp of most recent processed frame. Used when looking up the
+  // transform to the target frame during anchor creation.
+  ros::Time prev_frame_timestamp_;
+
   // A flag indicating that the node will use an approximate time synchronization  
   // policy to synchronize the images with the camera_info messages instead of the 
   // exact synchronizer

--- a/asa_ros/src/asa_ros_node.cpp
+++ b/asa_ros/src/asa_ros_node.cpp
@@ -2,7 +2,6 @@
 
 #include <cv_bridge/cv_bridge.h>
 #include <tf2_eigen/tf2_eigen.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <Eigen/Geometry>
 
 #include "asa_ros/asa_ros_node.h"

--- a/asa_ros_msgs/srv/CreateAnchor.srv
+++ b/asa_ros_msgs/srv/CreateAnchor.srv
@@ -1,7 +1,11 @@
-# Pose of the desired anchor expressed in the world frame.
-# If not set, will set it to identity (i.e., world frame) in a Z-up,
+# Frame_id for target frame.  Defaults to world frame.
+# The desired anchor pose should be expressed relative to this frame.
+string target_frame
+
+# Pose of the desired anchor expressed in the target frame.
+# If not set, will set it to identity (i.e., target frame) in a Z-up,
 # X-forward coordinate system (ROS canonical).
-geometry_msgs/TransformStamped anchor_in_world_frame
+geometry_msgs/TransformStamped anchor_in_target_frame
 ---
 # Since anchor creation takes several seconds, the actual anchor ID, etc. will
 # be published on the /created_anchor topic.


### PR DESCRIPTION
Anchors can now be created relative to an arbitrary target frame, and the transform given in the service call is used with the target frame pose in the world frame (looked up from TF at the time of creation) to compute the `anchor_in_world_frame` transformation.  Defaults to expected behavior of placing the anchor at the world frame origin if `target_frame` is not provided.