### PR TITLE
Cache last anchor

### DIFF
--- a/asa_ros/include/asa_ros/asa_ros_node.h
+++ b/asa_ros/include/asa_ros/asa_ros_node.h
@@ -113,13 +113,17 @@ class AsaRosNode {
   // A flag indicating that the node will use an approximate time synchronization  
   // policy to synchronize the images with the camera_info messages instead of the 
   // exact synchronizer
-  bool use_approx_sync_policy;
+  bool use_approx_sync_policy_;
 
   // The queue size of the subscribers used for the image and camera_info topic
-  int queue_size;
+  int queue_size_;
 
   // A flag that tells the asa interface to log debug logs
-  bool activate_interface_level_logging;
+  bool activate_interface_level_logging_;
+
+  // Flag to select whether to query the last anchor that was created and read
+  // the anchor id from a cache file, or to manually provide one.
+  bool query_last_anchor_id_from_cache_;
 
   // Cache of which anchors are currently being queried. This will be only used
   // when reset() (but not resetCompletely() is called, to restart any

--- a/asa_ros/include/asa_ros/asa_ros_node.h
+++ b/asa_ros/include/asa_ros/asa_ros_node.h
@@ -132,6 +132,9 @@ class AsaRosNode {
   // the anchor id from a cache file, or to manually provide one.
   bool query_last_anchor_id_from_cache_;
 
+  // Path to anchor id cache.  Defaults to ~/.ros/last_anchor_id
+  std::string last_anchor_cache_path_;
+
   // Cache of which anchors are currently being queried. This will be only used
   // when reset() (but not resetCompletely() is called, to restart any
   // previous watchers.

--- a/asa_ros/include/asa_ros/asa_ros_node.h
+++ b/asa_ros/include/asa_ros/asa_ros_node.h
@@ -68,6 +68,13 @@ class AsaRosNode {
   // Timer callbacks.
   void createAnchorTimerCallback(const ros::TimerEvent& e);
 
+  // Functions to read and write anchor ids from files for caching
+  // Automatically stores last created anchor to $ROS_HOME/last_anchor_id
+  // If query_last_anchor_id_from_cache param is true, then the node
+  // reads the id from this file and queries for that one.
+  std::string readCachedAnchorId();
+  bool storeAnchorIdInCache(const std::string& created_anchor_id);
+
   // Nodehandles, publishers, subscribers.
   ros::NodeHandle nh_;
   ros::NodeHandle nh_private_;

--- a/asa_ros/launch/asa_ros.launch
+++ b/asa_ros/launch/asa_ros.launch
@@ -22,6 +22,9 @@
   <!-- If true the asa interface loggs Debug Messages and Errors to the screen -->
   <arg name="activate_interface_level_logging" default="false"/>
 
+  <!-- If true, query the last anchor id that was created from this machine. -->
+  <arg name="query_last_anchor_id_from_cache" default="true"/>
+
   <node name="asa_ros" type="asa_ros_node" pkg="asa_ros" output="screen" clear_params="true">
     <remap from="image" to="/camera/fisheye1_rect/image" />
     <remap from="camera_info" to="/camera/fisheye1_rect/camera_info" />
@@ -43,6 +46,8 @@
     <param name="use_approx_sync_policy" value="$(arg use_approx_sync_policy)"/>
     <param name="subscriber_queue_size" value="$(arg subscriber_queue_size)"/>
     <param name="activate_interface_level_logging" value="$(arg activate_interface_level_logging)"/>
+
+    <param name="query_last_anchor_id_from_cache" value="$(arg query_last_anchor_id_from_cache)"/>
 
     <param name="anchor_id" value="$(arg anchor_id)" />
   </node>

--- a/asa_ros/src/asa_interface.cpp
+++ b/asa_ros/src/asa_interface.cpp
@@ -505,7 +505,7 @@ void AzureSpatialAnchorsInterface::ActivateInterfaceLevelLogging(){
   
   session_->LogLevel(Microsoft::Azure::SpatialAnchors::SessionLogLevel::All);
   session_->Diagnostics()->LogLevel(Microsoft::Azure::SpatialAnchors::SessionLogLevel::All);
-  session_->Diagnostics()->LogDirectory("/home/mrdrone/");
+  session_->Diagnostics()->LogDirectory("/tmp");
   LOG(INFO) << "Diagnostics LogDirectory: " << session_->Diagnostics()->LogDirectory();
   LOG(INFO) << "Diagnostics LogLevel: " << (int32_t)session_->Diagnostics()->LogLevel();
   LOG(INFO) << "Session LogLevel: " << (int32_t)session_->LogLevel();

--- a/asa_ros/src/asa_ros_node.cpp
+++ b/asa_ros/src/asa_ros_node.cpp
@@ -55,7 +55,7 @@ void AsaRosNode::initFromRosParams() {
                                  last_anchor_cache_path_,
                                  last_anchor_cache_path_default);
 
-  if(queue_size_ > 1 || use_approx_sync_policy_) {
+  if(use_approx_sync_policy_) {
     ROS_INFO_STREAM("Starting image and info subscribers with approximate " <<
                     "time sync, where queue size is " << queue_size_);
   }
@@ -302,9 +302,9 @@ std::string AsaRosNode::readCachedAnchorId() {
   // Try to read cache file
   std::ifstream cache_file(last_anchor_cache_path_.c_str());
   if(cache_file) {
-    std::ostringstream ss;
-    ss << cache_file.rdbuf();
-    cached_anchor_id = ss.str();
+    std::ostringstream string_stream;
+    string_stream << cache_file.rdbuf();
+    cached_anchor_id = string_stream.str();
     ROS_INFO_STREAM("Read anchor id: " << cached_anchor_id << " from cache");
   }
   else {

--- a/asa_ros/src/asa_ros_node.cpp
+++ b/asa_ros/src/asa_ros_node.cpp
@@ -127,7 +127,7 @@ void AsaRosNode::initFromRosParams() {
     std::bind(&AsaRosNode::createAnchorFeedbackCallback, this,
               std::placeholders::_1, std::placeholders::_2,
               std::placeholders::_3));
-  if(activate_interface_level_logging){
+  if(activate_interface_level_logging_){
     interface_->ActivateInterfaceLevelLogging();
   }
   interface_->start();

--- a/asa_ros/src/asa_ros_node.cpp
+++ b/asa_ros/src/asa_ros_node.cpp
@@ -27,20 +27,21 @@ AsaRosNode::~AsaRosNode() {}
 
 void AsaRosNode::initFromRosParams() {
 
-  nh_private_.param("subscriber_queue_size", queue_size, 1);
-  nh_private_.param("use_approx_sync_policy", use_approx_sync_policy, false);
-  nh_private_.param("activate_interface_level_logging", activate_interface_level_logging, false);
+  nh_private_.param("subscriber_queue_size", queue_size_, 1);
+  nh_private_.param("use_approx_sync_policy", use_approx_sync_policy_, false);
+  nh_private_.param("activate_interface_level_logging", activate_interface_level_logging_, false);
+  nh_private_.param("query_last_anchor_id_from_cache", query_last_anchor_id_from_cache_, false);
 
-  if(queue_size > 1 || use_approx_sync_policy) {
-    ROS_INFO_STREAM("Starting image and info subscribers with approximate time sync, where que-size is " << queue_size);
+  if(queue_size_ > 1 || use_approx_sync_policy_) {
+    ROS_INFO_STREAM("Starting image and info subscribers with approximate time sync, where queue size is " << queue_size_);
   }
 
   // Subscribe to the camera images.
-  image_sub_.subscribe(nh_, "image", queue_size);
-  info_sub_.subscribe(nh_, "camera_info", queue_size);
+  image_sub_.subscribe(nh_, "image", queue_size_);
+  info_sub_.subscribe(nh_, "camera_info", queue_size_);
   
-  if(use_approx_sync_policy) {
-    image_info_approx_sync_.reset(new message_filters::Synchronizer<CameraSyncPolicy>(CameraSyncPolicy(queue_size), image_sub_, info_sub_));
+  if(use_approx_sync_policy_) {
+    image_info_approx_sync_.reset(new message_filters::Synchronizer<CameraSyncPolicy>(CameraSyncPolicy(queue_size_), image_sub_, info_sub_));
     image_info_approx_sync_->registerCallback(boost::bind(&AsaRosNode::imageAndInfoCallback, this, _1, _2));
   } else {
     image_info_sync_.reset(
@@ -99,7 +100,7 @@ void AsaRosNode::initFromRosParams() {
 
   interface_.reset(new AzureSpatialAnchorsInterface(asa_config));
 
-  if(activate_interface_level_logging){
+  if(activate_interface_level_logging_){
     interface_->ActivateInterfaceLevelLogging();
   }
   


### PR DESCRIPTION
For some use cases, it would be helpful to query the last anchor that was created, without needing to manually manage the anchor id.  In the case that the node is shut down and the `created_anchor` topic is no longer available, this also allows the user to recover the anchor id afterwards.  

The id is written as a string to `$HOME/.ros/last_anchor_id` by default, or to `/tmp/last_anchor_id` if `$HOME` is not defined.  

The anchor id is cached automatically, but querying this anchor on future runs of the node can be enabled by setting the `query_last_anchor_id_from_cache` parameter to true.