### PR TITLE
Modified FindAnchors.srv to specify multiple IDs using a vector.

### DIFF
--- a/asa_ros/CMakeLists.txt
+++ b/asa_ros/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(asa_ros)
 
+# Deprecation Warning
+message(DEPRECATION "The anchor_id member of FindAnchor.srv is deprecated and will be \
+removed in a future release. Use the anchor_ids vector member instead.")
+
 add_definitions(-std=c++1z)
 
 find_package(catkin_simple REQUIRED)

--- a/asa_ros/include/asa_ros/asa_ros_node.h
+++ b/asa_ros/include/asa_ros/asa_ros_node.h
@@ -62,6 +62,11 @@ class AsaRosNode {
   bool resetCallback(std_srvs::EmptyRequest& req, std_srvs::EmptyResponse& res);
   bool resetCompletelyCallback(std_srvs::EmptyRequest& req,
                                std_srvs::EmptyResponse& res);
+  
+  // Helper function which converts a vector of IDs into a
+  // single comma-separated string, of the sort expected by
+  // AsaRosNode::queryAnchors()
+  std::string convertIdVectorToString(const std::vector<std::string>& vec) const;
 
   // Wrappers for commonly-used calls to the interface.
   // Queries COMMA-SEPARATED list of anchor IDs, and caches them in case the

--- a/asa_ros_msgs/srv/FindAnchor.srv
+++ b/asa_ros_msgs/srv/FindAnchor.srv
@@ -2,5 +2,9 @@
 # created on the same Azure Spatial Anchors account as used in this ROS node.
 # Found anchors will be published on the /found_anchor topic.
 # Note that you can be searching for multiple anchors at once.
+string[] anchor_ids
+
+# DEPRECATED: The anchor_id member is deprecated and will be removed in a future release.
+#             Use the anchor_ids vector member instead.
 string anchor_id
 ---


### PR DESCRIPTION
See Issue #23 . This has been tested to confirm functionality.

In a few months I'll submit another PR to remove the deprecated service member.